### PR TITLE
Major refactoring to support analysis of multiple groups

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -112,7 +112,7 @@ def get_censored_df(survival_days : pd.Series, exit_status : pd.Series, ids : pd
     return censored_df
 
 def get_exit_status(data : pd.DataFrame,type : str) -> pd.Series:
-    """Get the exit status of all patients. If type is "vital" this should be true if they are dead and false if they are alive. If type is "progress" this should be true if they have progressed and false if they have not.
+    """Get the exit status of all patients. If type is "survival" this should be true if they are dead and false if they are alive. If type is "progression" this should be true if they have progressed and false if they have not.
 
     :param data: the input data frame
     :type data: pd.DataFrame

--- a/src/app.py
+++ b/src/app.py
@@ -4,6 +4,7 @@ import numpy as np
 from typing import Tuple
 import os
 import sys
+import json
 from sksurv.nonparametric import kaplan_meier_estimator
 from sksurv.compare import compare_survival
 
@@ -18,84 +19,52 @@ def load_data(data_path : str) -> pd.DataFrame:
     data = pd.read_csv(data_path,sep="\t")
     return data
 
-def get_survival_days_from_dates(data : pd.DataFrame,census_date_column : str) -> Tuple[pd.Series, pd.Series]:
+def get_survival_days_from_dates(data : pd.DataFrame) -> Tuple[pd.Series, pd.Series]:
     """Get the number of days survival given the diagnosis date and the last follow up date.
 
     :param data: A pandas dataframe with the columns "diagnosis_date" and "vital_status_change_date" or "progression_status_change_date"
     :type data: pd.DataFrame
-    :param census_date_column: the name of the column containing the last follow up date this can be either "vital_status_change_date" or "progression_status_change_date"
-    :type census_date_column: str
     :return: A tuple with the survival days and a boolean series indicating if the calculation returned a not null value
     :rtype: Tuple[pd.Series, pd.Series]
     """
-    # check the value of the census_date_column
-    if census_date_column not in ["vital_status_change_date","progression_status_change_date"]:
-        raise ValueError(f"Column {census_date_column} not in ['vital_status_change_date','progression_status_change_date']")
-    if census_date_column not in data.columns:
-        raise ValueError(f"Column {census_date_column} not in data")
+
     
     diag_date = pd.to_datetime(data["diagnosis_date"])
-    census_date = pd.to_datetime(data[census_date_column])
+    census_date = pd.to_datetime(data["status_change_date"])
     survival_days = (census_date - diag_date).dt.days
     success=survival_days.isna()==False
     return survival_days, success
 
-def get_survival_days_from_days(data : pd.DataFrame, census_day_column : str) -> Tuple[pd.Series, pd.Series]:
+def get_survival_days_from_days(data : pd.DataFrame) -> Tuple[pd.Series, pd.Series]:
     """Get the number of days survival given the number of days survival (specified exactly in the data frame
 
     :param data: A pandas dataframe with the column "vital_status_change_day" or "progression_status_change_day"
     :type data: pd.DataFrame
-    :type census_day_column: the name of the column containing the last follow up day this can be either "vital_status_change_day" or "progression_status_change_day"
-    :return: A tuple with the survival days and a boolean series indicating if the number of days survival is not null
     :rtype: Tuple[pd.Series, pd.Series]
     """
-    # check the value of the census_day_column
-    if census_day_column not in ["vital_status_change_day","progression_status_change_day"]:
-        raise ValueError(f"Column {census_day_column} not in ['vital_status_change_day','progression_status_change_day']")
-    if census_day_column not in data.columns:
-        raise ValueError(f"Column {census_day_column} not in data")
     
-    survival_days=data["vital_status_change_day"]
+    survival_days=data["status_change_day"]
     survival_days.name="survival_days"
     survival_days=survival_days.astype(float)
     success=survival_days.isna()==False
     return survival_days, success
 
-def get_survival_columns(type : str) -> Tuple[str,str]:
-    """Get the names of the columns containing the survival dates and the last follow up dates
 
-    :param type: the type of survival days to get. This can be either "progress" for progression free survival or "vital" for overall survival
-    :type type: str
-    :return: A tuple with the names of the columns containing the survival dates and the last follow up dates
-    :rtype: Tuple[str,str]
-    """
-    if type not in ["progress","vital"]:
-        raise ValueError(f"Type {type} not in ['progress','vital']")
-    if type=="progress":
-        return "progression_status_change_date","progression_status_change_day"
-    else:
-        return "vital_status_change_date","vital_status_change_day"
-
-
-
-def get_survival_days(data : pd.DataFrame,type : str) -> pd.Series:
+def get_survival_days(data : pd.DataFrame) -> pd.Series:
     """Get the number of days survival from the data frame.
+    
     :param data: the input data frame
-    :type data: pd.DataFrame
-    :param type: the type of survival days to get. This can be either "progress" for progression free survival or "vital" for overall survival
     :return: pd.DataFrame
     """
     
-    # get the names of the columns containing the survival dates and the last follow up dates depending on the type
-    date_col,day_col=get_survival_columns(type)
+
     # initialise data frame
     survival_days = pd.Series(index=range(len(data)),name="survival_days",dtype=float)
     # try to get survival days from the dates
-    s1,success = get_survival_days_from_dates(data,date_col)
-    
+    s1,success = get_survival_days_from_dates(data)
     survival_days.iloc[np.array(success)]=s1.iloc[np.array(success)]
     # if not possible, get survival days from the days
-    survival_days.iloc[np.array(~success)]= get_survival_days_from_days(data,day_col)[0].iloc[np.array(~success)]
+    survival_days.iloc[np.array(~success)]= get_survival_days_from_days(data)[0].iloc[np.array(~success)]
     return survival_days
     
 def estimate_survival_function(survival : pd.Series, exit_status : pd.Series) -> pd.DataFrame:
@@ -110,6 +79,11 @@ def estimate_survival_function(survival : pd.Series, exit_status : pd.Series) ->
     """
     time, survival_prob, conf_int = kaplan_meier_estimator(
     exit_status, survival, conf_type="log-log")
+    
+    # add point to the beginning (for plotting) representing the time 0
+    time = np.concatenate([[0], time])
+    survival_prob = np.concatenate([[1], survival_prob])
+    conf_int = np.concatenate([np.array([[1],[1]]), conf_int],axis=1)
     survival_df = pd.DataFrame({
         'time': time,
         'survival_prob': survival_prob,
@@ -142,19 +116,19 @@ def get_exit_status(data : pd.DataFrame,type : str) -> pd.Series:
 
     :param data: the input data frame
     :type data: pd.DataFrame
-    :param type: the type of survival days. This can be either "progress" for progression free survival or "vital" for overall survival
+    :param type: the type of survival days. This can be either "progression" for progression free survival or "survival" for overall survival
     :return: a boolean series indicating if the patient died
     :rtype: pd.Series
     """
     # check type value
-    if type not in ["progress","vital"]:
-        raise ValueError(f"Type {type} not in ['progress','vital']")
+    if type not in ["progression","survival"]:
+        raise ValueError(f"Type {type} not in ['progression','survival']")
     
-    if type == "vital":
-        return data["vital_status"]==False
+    if type == "survival":
+        return data["status"]==False
     
-    if type == "progress":
-        return data["progression_status"]==True
+    if type == "progression":
+        return data["status"]==True
 
 
 def get_labels(data : pd.DataFrame) -> pd.Series:
@@ -214,38 +188,63 @@ def logrank_test(survival_days : pd.Series,exit_status : pd.Series,label : pd.Se
     chi2, p = compare_survival(survival_data, label)   
     return pd.DataFrame({"chi2":chi2,"p":p},index=["logrank_test"]) 
 
+def concatenate_dfs_add_label(dfs : list,label : str) -> pd.DataFrame:
+    """Concatenate a list of data frames and add a column with the label
 
-def main(root_path : str,type : str):
+    :param dfs: a list of data frames
+    :type dfs: list
+    :param label: the label to add to the data frames
+    :type label: str
+    :return: a data frame with the data frames concatenated and the label column added
+    :rtype: pd.DataFrame
+    """
+    for i,df in enumerate(dfs):
+        df["label"]=label[i]
+    return pd.concat(dfs,ignore_index=True)
+
+
+def read_options_file(root_path : str) -> dict:
+    # read the options from the options file
+    with open(os.path.join(root_path,"options.json"), 'r') as f:
+        config = json.load(f)
+    
+    # Get the type of survival days to get from the JSON file
+    mode = config.get("mode")
+    assert mode in ["progression","survival"], "mode must be either 'progression' or 'survival'"
+    return {'mode':mode}
+    
+def main(root_path : str):
     """Main function to estimate the survival functions from the input data and write the result to a file result.tsv. Also writes censored.tsv which contains the survival days of all right censored patients.
     Does this separately for each group label in the input data (in the "label") column.
     
-    :param root_path: the path in which the input.tsv file is located and where the output files will be written
     :param type: the type of survival days to get. This can be either "progress" for progression free survival or "vital" for overall survival
     :type root_path: str
     """
     # load the data
     data = load_data(os.path.join(root_path,"input.tsv"))
+    opts = read_options_file(root_path)
+    mode = opts["mode"]
+    
     # get the labels of the groups
     label = get_labels(data)
     # get the data subsetted by label
     subsets,unique_labels = get_subsets(data,label)
-    # get the survival days and exit status (event binary indicator) for each group
-    survival_days = [get_survival_days(subset,type) for subset in subsets]
-    exit_status = [get_exit_status(subset,type) for subset in subsets]
     
-    # print the length of the survival days and exit status
-    print([len(s) for s in survival_days])
-    print([len(s) for s in exit_status])
-    print(unique_labels)
+    # get the survival days and exit status (event binary indicator) for each group
+    survival_days = [get_survival_days(subset) for subset in subsets]
+    exit_status = [get_exit_status(subset,mode) for subset in subsets]
     
     # get the survival function and censored data data frame for each group
     survival_functions, censored_dfs = zip(*[get_survival_function_and_censored_dfs(s,e,d.sample_id) for s,e,d in zip(survival_days,exit_status,subsets)])    
     
-    # write the survival functions each to a separate file
-    for l,s,c in zip(unique_labels,survival_functions,censored_dfs):
-        s.to_csv(os.path.join(root_path,f"result{l}.tsv"), sep="\t", index=False)
-        c.to_csv(os.path.join(root_path,f"censored{l}.tsv"), sep="\t", index=False)
+    # write the survival functions to a file
+    survival_functions_df = concatenate_dfs_add_label(survival_functions,unique_labels)
+    survival_functions_df.to_csv(os.path.join(root_path,"result.tsv"), sep="\t", index=False)
     
+    # write the censored data to a file
+    censored_df = concatenate_dfs_add_label(censored_dfs,unique_labels)
+    censored_df.to_csv(os.path.join(root_path,"censored.tsv"), sep="\t", index=False)
+       
     # perform the logrank test if there is more than one group
     if len(unique_labels) > 1:
         logrank = logrank_test(pd.concat(survival_days),pd.concat(exit_status),label)
@@ -254,5 +253,4 @@ def main(root_path : str,type : str):
 
 if __name__ == "__main__":
     root_path = sys.argv[1]
-    type = sys.argv[2]
-    main(root_path,type)
+    main(root_path)

--- a/src/app.py
+++ b/src/app.py
@@ -1,9 +1,11 @@
 import argparse
 import pandas as pd
+import numpy as np
 from typing import Tuple
 import os
 import sys
 from sksurv.nonparametric import kaplan_meier_estimator
+from sksurv.compare import compare_survival
 
 def load_data(data_path : str) -> pd.DataFrame:
     """Reads a tsv file into a pandas.DataFrame
@@ -16,49 +18,84 @@ def load_data(data_path : str) -> pd.DataFrame:
     data = pd.read_csv(data_path,sep="\t")
     return data
 
-def get_survival_days_from_dates(data : pd.DataFrame) -> Tuple[pd.Series, pd.Series]:
+def get_survival_days_from_dates(data : pd.DataFrame,census_date_column : str) -> Tuple[pd.Series, pd.Series]:
     """Get the number of days survival given the diagnosis date and the last follow up date.
 
-    :param data: A pandas dataframe with the columns "diagnosis_date" and "vital_status_change_date"
+    :param data: A pandas dataframe with the columns "diagnosis_date" and "vital_status_change_date" or "progression_status_change_date"
     :type data: pd.DataFrame
+    :param census_date_column: the name of the column containing the last follow up date this can be either "vital_status_change_date" or "progression_status_change_date"
+    :type census_date_column: str
     :return: A tuple with the survival days and a boolean series indicating if the calculation returned a not null value
     :rtype: Tuple[pd.Series, pd.Series]
     """
+    # check the value of the census_date_column
+    if census_date_column not in ["vital_status_change_date","progression_status_change_date"]:
+        raise ValueError(f"Column {census_date_column} not in ['vital_status_change_date','progression_status_change_date']")
+    if census_date_column not in data.columns:
+        raise ValueError(f"Column {census_date_column} not in data")
     
     diag_date = pd.to_datetime(data["diagnosis_date"])
-    census_date = pd.to_datetime(data["vital_status_change_date"])
+    census_date = pd.to_datetime(data[census_date_column])
     survival_days = (census_date - diag_date).dt.days
     success=survival_days.isna()==False
     return survival_days, success
 
-def get_survival_days_from_days(data : pd.DataFrame) -> Tuple[pd.Series, pd.Series]:
+def get_survival_days_from_days(data : pd.DataFrame, census_day_column : str) -> Tuple[pd.Series, pd.Series]:
     """Get the number of days survival given the number of days survival (specified exactly in the data frame
 
-    :param data: A pandas dataframe with the column "vital_status_change_day"
+    :param data: A pandas dataframe with the column "vital_status_change_day" or "progression_status_change_day"
     :type data: pd.DataFrame
+    :type census_day_column: the name of the column containing the last follow up day this can be either "vital_status_change_day" or "progression_status_change_day"
     :return: A tuple with the survival days and a boolean series indicating if the number of days survival is not null
     :rtype: Tuple[pd.Series, pd.Series]
     """
+    # check the value of the census_day_column
+    if census_day_column not in ["vital_status_change_day","progression_status_change_day"]:
+        raise ValueError(f"Column {census_day_column} not in ['vital_status_change_day','progression_status_change_day']")
+    if census_day_column not in data.columns:
+        raise ValueError(f"Column {census_day_column} not in data")
+    
     survival_days=data["vital_status_change_day"]
     survival_days.name="survival_days"
     survival_days=survival_days.astype(float)
     success=survival_days.isna()==False
     return survival_days, success
 
-def get_survival_days(data : pd.DataFrame) -> pd.Series:
+def get_survival_columns(type : str) -> Tuple[str,str]:
+    """Get the names of the columns containing the survival dates and the last follow up dates
+
+    :param type: the type of survival days to get. This can be either "progress" for progression free survival or "vital" for overall survival
+    :type type: str
+    :return: A tuple with the names of the columns containing the survival dates and the last follow up dates
+    :rtype: Tuple[str,str]
+    """
+    if type not in ["progress","vital"]:
+        raise ValueError(f"Type {type} not in ['progress','vital']")
+    if type=="progress":
+        return "progression_status_change_date","progression_status_change_day"
+    else:
+        return "vital_status_change_date","vital_status_change_day"
+
+
+
+def get_survival_days(data : pd.DataFrame,type : str) -> pd.Series:
     """Get the number of days survival from the data frame.
-    :param data: 
+    :param data: the input data frame
     :type data: pd.DataFrame
+    :param type: the type of survival days to get. This can be either "progress" for progression free survival or "vital" for overall survival
     :return: pd.DataFrame
     """
+    
+    # get the names of the columns containing the survival dates and the last follow up dates depending on the type
+    date_col,day_col=get_survival_columns(type)
     # initialise data frame
     survival_days = pd.Series(index=range(len(data)),name="survival_days",dtype=float)
     # try to get survival days from the dates
-    s1,success = get_survival_days_from_dates(data)
+    s1,success = get_survival_days_from_dates(data,date_col)
     
-    survival_days[success]=s1[success]
+    survival_days.iloc[np.array(success)]=s1.iloc[np.array(success)]
     # if not possible, get survival days from the days
-    survival_days[~success]= get_survival_days_from_days(data)[0][~success]
+    survival_days.iloc[np.array(~success)]= get_survival_days_from_days(data,day_col)[0].iloc[np.array(~success)]
     return survival_days
     
 def estimate_survival_function(survival : pd.Series, exit_status : pd.Series) -> pd.DataFrame:
@@ -81,43 +118,141 @@ def estimate_survival_function(survival : pd.Series, exit_status : pd.Series) ->
     })
     return survival_df
 
-def get_censored_df(survival_days : pd.Series, exit_status : pd.Series, data : pd.DataFrame) -> pd.DataFrame:
+def get_censored_df(survival_days : pd.Series, exit_status : pd.Series, ids : pd.Series) -> pd.DataFrame:
     """Return a data frame containing the survival days of all censored patients (those who were still alive at last follow up)
     
     :param survival_days: the days survival of all patients
     :type survival_days: pd.Series
     :param exit_status: the exit status of all patients (True if dead, False if alive)
     :type exit_status: pd.Series
-    :param data: the input data frame
-    :type data: pd.DataFrame
+    :param ids: the ids of the patients
+    :type ids: pd.DataFrame
     :return: a data frame containing the survival days of all censored patients. It will contain two columns 'sample_id' 'days_at_censoring'
     :rtype: pd.DataFrame
     """
     
     censored=exit_status==False
-    sample_id=data["sample_id"][censored]
-    days_at_censoring=survival_days[censored]
+    sample_id=ids[censored]
+    days_at_censoring=survival_days.iloc[np.array(censored)]
     censored_df=pd.DataFrame({"sample_id":sample_id,"days_at_censoring":days_at_censoring})
     return censored_df
 
+def get_exit_status(data : pd.DataFrame,type : str) -> pd.Series:
+    """Get the exit status of all patients. If type is "vital" this should be true if they are dead and false if they are alive. If type is "progress" this should be true if they have progressed and false if they have not.
+
+    :param data: the input data frame
+    :type data: pd.DataFrame
+    :param type: the type of survival days. This can be either "progress" for progression free survival or "vital" for overall survival
+    :return: a boolean series indicating if the patient died
+    :rtype: pd.Series
+    """
+    # check type value
+    if type not in ["progress","vital"]:
+        raise ValueError(f"Type {type} not in ['progress','vital']")
+    
+    if type == "vital":
+        return data["vital_status"]==False
+    
+    if type == "progress":
+        return data["progression_status"]==True
 
 
-def main(root_path : str):
-    """Main function to estimate the survival function from the input data and write the result to a file result.tsv. Also writes censored.tsv which contains the survival days of all right censored patients.
+def get_labels(data : pd.DataFrame) -> pd.Series:
+    """Get the labels of the groups in the data frame
+
+    :param data: the input data frame
+    :type data: pd.DataFrame
+    :return: a series with the labels
+    :rtype: pd.Series
+    """
+    if "label" not in data.columns:
+        return pd.Series(np.zeros(len(data),dtype=int),dtype=str)
+    return data["label"]
+
+def get_subsets(data : pd.DataFrame,label : pd.Series) -> list:
+    """Get the subsets of the data frame for each label
+    
+    :param data: the input data frame
+    :type data: pd.DataFrame
+    """
+    return [data.iloc[np.array(label==l),:] for l in label.unique()],label.unique()
+
+def get_survival_function_and_censored_dfs(survival_days : pd.Series,exit_status : pd.Series,ids : pd.Series) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Get the survival function and censored data frame from the survival days and exit status
+
+    :param survival_days: the number of days survival
+    :type survival_days: pd.Series
+    :param exit_status: the exit status of the patients
+    :type exit_status: pd.Series
+    :param ids: the ids of the patients
+    :type data: pd.DataFrame
+    :return: a tuple with the survival function and the censored data frame
+    :rtype: Tuple[pd.DataFrame, pd.DataFrame
+    
+    """
+    output = estimate_survival_function(survival_days, exit_status)
+    output_censored = get_censored_df(survival_days, exit_status, ids)
+    return output, output_censored
+
+
+def logrank_test(survival_days : pd.Series,exit_status : pd.Series,label : pd.Series) -> pd.DataFrame:
+    """Perform the logrank test comparing the survival curves of two or more groups
+
+    :param survival_days: the number of days survival
+    :type survival_days: pd.Series
+    :param exit_status: the exit status of the patients
+    :type exit_status: pd.Series
+    :param label: the labels of the groups
+    :type label: pd.Series
+    :return: a data frame with the chi2 and p values of the logrank test
+    :rtype: pd.DataFrame
+    """
+    # crate a structured array with the survival days and exit status
+    survival_data = np.zeros(len(survival_days), dtype=[('status', bool), ('time', float)])
+    survival_data['status'] = exit_status
+    survival_data['time'] = survival_days
+    chi2, p = compare_survival(survival_data, label)   
+    return pd.DataFrame({"chi2":chi2,"p":p},index=["logrank_test"]) 
+
+
+def main(root_path : str,type : str):
+    """Main function to estimate the survival functions from the input data and write the result to a file result.tsv. Also writes censored.tsv which contains the survival days of all right censored patients.
+    Does this separately for each group label in the input data (in the "label") column.
     
     :param root_path: the path in which the input.tsv file is located and where the output files will be written
+    :param type: the type of survival days to get. This can be either "progress" for progression free survival or "vital" for overall survival
     :type root_path: str
     """
-    data = load_data(os.path.join(root_path, "input.tsv"))  
-    survival_days = get_survival_days(data)
-    exit_status=data["vital_status"]==False #True if dead, False if alive
-    output = estimate_survival_function(survival_days, exit_status)
-    output_censored = get_censored_df(survival_days, exit_status, data)
-    # write output to files
-    output.to_csv(os.path.join(root_path,"result.tsv"), index=False,sep="\t")
-    output_censored.to_csv(os.path.join(root_path,"censored.tsv"), index=False,sep="\t")
-    print("Done")
+    # load the data
+    data = load_data(os.path.join(root_path,"input.tsv"))
+    # get the labels of the groups
+    label = get_labels(data)
+    # get the data subsetted by label
+    subsets,unique_labels = get_subsets(data,label)
+    # get the survival days and exit status (event binary indicator) for each group
+    survival_days = [get_survival_days(subset,type) for subset in subsets]
+    exit_status = [get_exit_status(subset,type) for subset in subsets]
     
+    # print the length of the survival days and exit status
+    print([len(s) for s in survival_days])
+    print([len(s) for s in exit_status])
+    print(unique_labels)
+    
+    # get the survival function and censored data data frame for each group
+    survival_functions, censored_dfs = zip(*[get_survival_function_and_censored_dfs(s,e,d.sample_id) for s,e,d in zip(survival_days,exit_status,subsets)])    
+    
+    # write the survival functions each to a separate file
+    for l,s,c in zip(unique_labels,survival_functions,censored_dfs):
+        s.to_csv(os.path.join(root_path,f"result{l}.tsv"), sep="\t", index=False)
+        c.to_csv(os.path.join(root_path,f"censored{l}.tsv"), sep="\t", index=False)
+    
+    # perform the logrank test if there is more than one group
+    if len(unique_labels) > 1:
+        logrank = logrank_test(pd.concat(survival_days),pd.concat(exit_status),label)
+        logrank.to_csv(os.path.join(root_path,"logrank_test.tsv"), sep="\t", index=False)
+    
+
 if __name__ == "__main__":
     root_path = sys.argv[1]
-    main(root_path)
+    type = sys.argv[2]
+    main(root_path,type)

--- a/src/app.py
+++ b/src/app.py
@@ -22,16 +22,16 @@ def load_data(data_path : str) -> pd.DataFrame:
 def get_survival_days_from_dates(data : pd.DataFrame) -> Tuple[pd.Series, pd.Series]:
     """Get the number of days survival given the diagnosis date and the last follow up date.
 
-    :param data: A pandas dataframe with the columns "diagnosis_date" and "vital_status_change_date" or "progression_status_change_date"
+    :param data: A pandas dataframe with the columns "enrolment_date" and "status_change_date"
     :type data: pd.DataFrame
     :return: A tuple with the survival days and a boolean series indicating if the calculation returned a not null value
     :rtype: Tuple[pd.Series, pd.Series]
     """
 
     
-    diag_date = pd.to_datetime(data["diagnosis_date"])
+    enrolment_date = pd.to_datetime(data["enrolment_date"])
     census_date = pd.to_datetime(data["status_change_date"])
-    survival_days = (census_date - diag_date).dt.days
+    survival_days = (census_date - enrolment_date).dt.days
     success=survival_days.isna()==False
     return survival_days, success
 
@@ -101,55 +101,42 @@ def get_censored_df(survival_days : pd.Series, exit_status : pd.Series, ids : pd
     :type exit_status: pd.Series
     :param ids: the ids of the patients
     :type ids: pd.DataFrame
-    :return: a data frame containing the survival days of all censored patients. It will contain two columns 'sample_id' 'days_at_censoring'
+    :return: a data frame containing the survival days of all censored patients. It will contain two columns 'donor_id' 'days_at_censoring'
     :rtype: pd.DataFrame
     """
     
     censored=exit_status==False
-    sample_id=ids[censored]
+    donor_id=ids[censored]
     days_at_censoring=survival_days.iloc[np.array(censored)]
-    censored_df=pd.DataFrame({"sample_id":sample_id,"days_at_censoring":days_at_censoring})
+    censored_df=pd.DataFrame({"donor_id":donor_id,"days_at_censoring":days_at_censoring})
     return censored_df
 
-def get_exit_status(data : pd.DataFrame,type : str) -> pd.Series:
-    """Get the exit status of all patients. If type is "survival" this should be true if they are dead and false if they are alive. If type is "progression" this should be true if they have progressed and false if they have not.
+def get_exit_status(data : pd.DataFrame) -> pd.Series:
+    """Get the exit status of all patients. 
+    :param data: the input data frame
+    :type data: pd.DataFrame
+    :rtype: pd.Series
+    """
+    return data["status"]
+def get_dataset_ids(data : pd.DataFrame) -> pd.Series:
+    """Get the dataset_ids of the groups in the data frame
 
     :param data: the input data frame
     :type data: pd.DataFrame
-    :param type: the type of survival days. This can be either "progression" for progression free survival or "survival" for overall survival
-    :return: a boolean series indicating if the patient died
+    :return: a series with the dataset_ids
     :rtype: pd.Series
     """
-    # check type value
-    if type not in ["progression","survival"]:
-        raise ValueError(f"Type {type} not in ['progression','survival']")
-    
-    if type == "survival":
-        return data["status"]==False
-    
-    if type == "progression":
-        return data["status"]==True
-
-
-def get_labels(data : pd.DataFrame) -> pd.Series:
-    """Get the labels of the groups in the data frame
-
-    :param data: the input data frame
-    :type data: pd.DataFrame
-    :return: a series with the labels
-    :rtype: pd.Series
-    """
-    if "label" not in data.columns:
+    if "dataset_id" not in data.columns:
         return pd.Series(np.zeros(len(data),dtype=int),dtype=str)
-    return data["label"]
+    return data["dataset_id"]
 
-def get_subsets(data : pd.DataFrame,label : pd.Series) -> list:
-    """Get the subsets of the data frame for each label
+def get_subsets(data : pd.DataFrame,dataset_id : pd.Series) -> list:
+    """Get the subsets of the data frame for each dataset_id
     
     :param data: the input data frame
     :type data: pd.DataFrame
     """
-    return [data.iloc[np.array(label==l),:] for l in label.unique()],label.unique()
+    return [data.iloc[np.array(dataset_id==l),:] for l in dataset_id.unique()],dataset_id.unique()
 
 def get_survival_function_and_censored_dfs(survival_days : pd.Series,exit_status : pd.Series,ids : pd.Series) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Get the survival function and censored data frame from the survival days and exit status
@@ -169,15 +156,15 @@ def get_survival_function_and_censored_dfs(survival_days : pd.Series,exit_status
     return output, output_censored
 
 
-def logrank_test(survival_days : pd.Series,exit_status : pd.Series,label : pd.Series) -> pd.DataFrame:
+def logrank_test(survival_days : pd.Series,exit_status : pd.Series,dataset_id : pd.Series) -> pd.DataFrame:
     """Perform the logrank test comparing the survival curves of two or more groups
 
     :param survival_days: the number of days survival
     :type survival_days: pd.Series
     :param exit_status: the exit status of the patients
     :type exit_status: pd.Series
-    :param label: the labels of the groups
-    :type label: pd.Series
+    :param dataset_id: the dataset_ids of the groups
+    :type dataset_id: pd.Series
     :return: a data frame with the chi2 and p values of the logrank test
     :rtype: pd.DataFrame
     """
@@ -185,69 +172,57 @@ def logrank_test(survival_days : pd.Series,exit_status : pd.Series,label : pd.Se
     survival_data = np.zeros(len(survival_days), dtype=[('status', bool), ('time', float)])
     survival_data['status'] = exit_status
     survival_data['time'] = survival_days
-    chi2, p = compare_survival(survival_data, label)   
+    chi2, p = compare_survival(survival_data, dataset_id)   
     return pd.DataFrame({"chi2":chi2,"p":p},index=["logrank_test"]) 
 
-def concatenate_dfs_add_label(dfs : list,label : str) -> pd.DataFrame:
-    """Concatenate a list of data frames and add a column with the label
+def concatenate_dfs_add_dataset_id(dfs : list,dataset_id : str) -> pd.DataFrame:
+    """Concatenate a list of data frames and add a column with the dataset_id
 
     :param dfs: a list of data frames
     :type dfs: list
-    :param label: the label to add to the data frames
-    :type label: str
-    :return: a data frame with the data frames concatenated and the label column added
+    :param dataset_id: the dataset_id to add to the data frames
+    :type dataset_id: str
+    :return: a data frame with the data frames concatenated and the dataset_id column added
     :rtype: pd.DataFrame
     """
     for i,df in enumerate(dfs):
-        df["label"]=label[i]
+        df["dataset_id"]=dataset_id[i]
     return pd.concat(dfs,ignore_index=True)
 
-
-def read_options_file(root_path : str) -> dict:
-    # read the options from the options file
-    with open(os.path.join(root_path,"options.json"), 'r') as f:
-        config = json.load(f)
-    
-    # Get the type of survival days to get from the JSON file
-    mode = config.get("mode")
-    assert mode in ["progression","survival"], "mode must be either 'progression' or 'survival'"
-    return {'mode':mode}
     
 def main(root_path : str):
     """Main function to estimate the survival functions from the input data and write the result to a file result.tsv. Also writes censored.tsv which contains the survival days of all right censored patients.
-    Does this separately for each group label in the input data (in the "label") column.
+    Does this separately for each group dataset_id in the input data (in the "dataset_id") column.
     
     :param type: the type of survival days to get. This can be either "progress" for progression free survival or "vital" for overall survival
     :type root_path: str
     """
     # load the data
     data = load_data(os.path.join(root_path,"input.tsv"))
-    opts = read_options_file(root_path)
-    mode = opts["mode"]
     
-    # get the labels of the groups
-    label = get_labels(data)
-    # get the data subsetted by label
-    subsets,unique_labels = get_subsets(data,label)
+    # get the dataset_ids of the groups
+    dataset_id = get_dataset_ids(data)
+    # get the data subsetted by dataset_id
+    subsets,unique_dataset_ids = get_subsets(data,dataset_id)
     
     # get the survival days and exit status (event binary indicator) for each group
     survival_days = [get_survival_days(subset) for subset in subsets]
-    exit_status = [get_exit_status(subset,mode) for subset in subsets]
+    exit_status = [get_exit_status(subset) for subset in subsets]
     
     # get the survival function and censored data data frame for each group
-    survival_functions, censored_dfs = zip(*[get_survival_function_and_censored_dfs(s,e,d.sample_id) for s,e,d in zip(survival_days,exit_status,subsets)])    
+    survival_functions, censored_dfs = zip(*[get_survival_function_and_censored_dfs(s,e,d.donor_id) for s,e,d in zip(survival_days,exit_status,subsets)])    
     
     # write the survival functions to a file
-    survival_functions_df = concatenate_dfs_add_label(survival_functions,unique_labels)
+    survival_functions_df = concatenate_dfs_add_dataset_id(survival_functions,unique_dataset_ids)
     survival_functions_df.to_csv(os.path.join(root_path,"result.tsv"), sep="\t", index=False)
     
     # write the censored data to a file
-    censored_df = concatenate_dfs_add_label(censored_dfs,unique_labels)
+    censored_df = concatenate_dfs_add_dataset_id(censored_dfs,unique_dataset_ids)
     censored_df.to_csv(os.path.join(root_path,"censored.tsv"), sep="\t", index=False)
        
     # perform the logrank test if there is more than one group
-    if len(unique_labels) > 1:
-        logrank = logrank_test(pd.concat(survival_days),pd.concat(exit_status),label)
+    if len(unique_dataset_ids) > 1:
+        logrank = logrank_test(pd.concat(survival_days),pd.concat(exit_status),dataset_id)
         logrank.to_csv(os.path.join(root_path,"logrank_test.tsv"), sep="\t", index=False)
     
 

--- a/test/data/input.tsv
+++ b/test/data/input.tsv
@@ -1,5 +1,0 @@
-sample_id	diagnosis_date	status	status_change_date	status_change_day	label
-Donor1	2020-01-01	true	2021-01-01		A
-Donor2	2020-01-01	false	2021-01-01	 366	B
-Donor3	2020-01-01	true	2021-01-01		B
-Donor4	2020-01-01	false	2021-01-01		B

--- a/test/data/input.tsv
+++ b/test/data/input.tsv
@@ -1,5 +1,5 @@
-sample_id	diagnosis_date	vital_status	vital_status_change_date	vital_status_change_day	progression_status	progression_status_change_date	progression_status_change_day	label
-Donor1	2020-01-01	true	2021-01-01		false	2021-01-01		A
-Donor2	2020-01-01	false	2021-01-01		true		 366	 B
-Donor3	2020-01-01	true	2021-01-01		true	2021-01-01		B
-Donor4	2020-01-01	false	2021-01-01		true	2021-01-01		B
+sample_id	diagnosis_date	status	status_change_date	status_change_day	label
+Donor1	2020-01-01	true	2021-01-01		A
+Donor2	2020-01-01	false	2021-01-01	 366	B
+Donor3	2020-01-01	true	2021-01-01		B
+Donor4	2020-01-01	false	2021-01-01		B

--- a/test/data/input.tsv
+++ b/test/data/input.tsv
@@ -1,5 +1,5 @@
-sample_id	diagnosis_date	vital_status	vital_status_change_date	vital_status_change_day
-Donor1	2020-01-01	true	2021-01-01	
-Donor2	2020-01-01	false	2021-01-01	
-Donor3	2020-01-01	true	2021-01-01	
-Donor4	2020-01-01	false	2021-01-01	
+sample_id	diagnosis_date	vital_status	vital_status_change_date	vital_status_change_day	progression_status	progression_status_change_date	progression_status_change_day	label
+Donor1	2020-01-01	true	2021-01-01		false	2021-01-01		A
+Donor2	2020-01-01	false	2021-01-01		true		 366	 B
+Donor3	2020-01-01	true	2021-01-01		true	2021-01-01		B
+Donor4	2020-01-01	false	2021-01-01		true	2021-01-01		B

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -6,7 +6,7 @@ from app import estimate_survival_function
 import pytest
 from unittest.mock import patch
 import pandas as pd
-from app import read_options_file,get_survival_days_from_dates, get_survival_days_from_days, get_survival_days, load_data, get_censored_df, get_exit_status, get_labels,get_subsets,  logrank_test, main
+from app import get_exit_status,get_survival_days_from_dates, get_survival_days_from_days, get_survival_days, load_data, get_censored_df,  get_dataset_ids,get_subsets,  logrank_test, main
 import numpy as np
 import os
 from collections import Counter
@@ -15,18 +15,18 @@ from collections import Counter
 def mock_survival_data():
     survival = pd.Series([5, 10, 15, 20, 25])
     exit_status = pd.Series([True, False, True, False, True])
-    label = pd.Series(["A", "B", "A", "B", "A"])
-    return survival, exit_status,label
+    dataset_id = pd.Series(["A", "B", "A", "B", "A"])
+    return survival, exit_status,dataset_id
 
 @pytest.fixture
 def mock_data_df():
     data = pd.DataFrame({
-        "diagnosis_date": ["2020-01-01", "2020-02-01", "2020-03-01"],
+        "enrolment_date": ["2020-01-01", "2020-02-01", "2020-03-01"],
         "status_change_date": ["2020-01-10", None, "2020-03-15"],
         "status_change_day": [9, 20, 14],
         "status": [False, True, False],
-        "label": ["A", "B", "A"],
-        "sample_id": ["1", "2", "3"]
+        "dataset_id": ["A", "B", "A"],
+        "donor_id": ["1", "2", "3"]
     })
     return data
 @pytest.fixture
@@ -47,30 +47,30 @@ def test_load_data():
      # Check if the DataFrame has the correct number of columns
      assert len(data.columns) == 6
      # Check if the DataFrame has the correct columns
-     expected_columns = ["sample_id","diagnosis_date","status","status_change_date","status_change_day","label"]
+     expected_columns = ["dataset_id","donor_id","enrolment_date","status","status_change_date","status_change_day"]
      assert list(data.columns) == expected_columns
 
-def test_get_labels(mock_data_df):
-    """ test the labels column is returned or a series of 0s if the column is not present"""
-    assert get_labels(mock_data_df).equals(pd.Series(["A", "B", "A"]))
-    # remove the label column
-    mock_data_df.drop("label", axis=1, inplace=True)
-    assert get_labels(mock_data_df).equals(pd.Series(["0", "0", "0"]))
+def test_get_dataset_ids(mock_data_df):
+    """ test the dataset_ids column is returned or a series of 0s if the column is not present"""
+    assert get_dataset_ids(mock_data_df).equals(pd.Series(["A", "B", "A"]))
+    # remove the dataset_id column
+    mock_data_df.drop("dataset_id", axis=1, inplace=True)
+    assert get_dataset_ids(mock_data_df).equals(pd.Series(["0", "0", "0"]))
 
 
 def test_get_subsets(mock_data_df):
     """ test the subsets of the data are returned """
-    labels = mock_data_df.label
-    subsets,unique_labels = get_subsets(mock_data_df,labels)
+    dataset_ids = mock_data_df.dataset_id
+    subsets,unique_dataset_ids = get_subsets(mock_data_df,dataset_ids)
     
     # check out put is a list of dataframes
     assert isinstance(subsets,list)
     assert all(isinstance(subset,pd.DataFrame) for subset in subsets)
     # check the subsets are as expected
-    assert subsets[0].equals(mock_data_df.iloc[np.array(mock_data_df.label=="A"),:])
-    assert subsets[1].equals(mock_data_df.iloc[np.array(mock_data_df.label=="B"),:])
-    # check the unique labels are as expected
-    assert Counter(unique_labels) == Counter(["A","B"])
+    assert subsets[0].equals(mock_data_df.iloc[np.array(mock_data_df.dataset_id=="A"),:])
+    assert subsets[1].equals(mock_data_df.iloc[np.array(mock_data_df.dataset_id=="B"),:])
+    # check the unique dataset_ids are as expected
+    assert Counter(unique_dataset_ids) == Counter(["A","B"])
     
 def test_get_survival_days_from_dates(mock_data_df):
     survival_days, success = get_survival_days_from_dates(mock_data_df)
@@ -136,18 +136,14 @@ def test_get_survival_days(mock_data_df):
     survival_days = get_survival_days(trunc_data)
     expected_survival_days = pd.Series([20, 14],index=[1,2],name="survival_days",dtype=float)
 
-@pytest.mark.parametrize("type", ["progression", "survival"])
-def test_get_exit_status(mock_data_df,type):
-    exit_status = get_exit_status(mock_data_df,type)
+
+def test_get_exit_status(mock_data_df):
+    exit_status = get_exit_status(mock_data_df)
     
     # Check if the result is a Series
     assert isinstance(exit_status, pd.Series)
-    
-    # Check if the Series has the correct values
-    if type == "progression":
-        expected_exit_status = pd.Series([False, True, False],name="status",dtype=bool)
-    if type == "survival":
-        expected_exit_status = pd.Series([True, False, True],name="status",dtype=bool)
+
+    expected_exit_status = pd.Series([False, True, False],name="status",dtype=bool)
     pd.testing.assert_series_equal(exit_status, expected_exit_status)
     
 
@@ -173,24 +169,24 @@ def mock_data_for_censored():
     survival_days = pd.Series([5, 10, 15, 20, 25])
     exit_status = pd.Series([True, False, True, False, True])
     data = pd.DataFrame({
-        "sample_id": ["A", "B", "C", "D", "E"]
+        "donor_id": ["A", "B", "C", "D", "E"]
     })
     return survival_days, exit_status, data
 
 def test_get_censored_df(mock_data_for_censored):
     survival_days, exit_status, data = mock_data_for_censored
-    result = get_censored_df(survival_days, exit_status, data.sample_id)
+    result = get_censored_df(survival_days, exit_status, data.donor_id)
     
     # Check if the result is a DataFrame
     assert isinstance(result, pd.DataFrame)
     
     # Check if the DataFrame has the correct columns
-    expected_columns = ["sample_id", "days_at_censoring"]
+    expected_columns = ["donor_id", "days_at_censoring"]
     assert list(result.columns) == expected_columns
     
     # Check if the DataFrame has the correct values
     expected_data = pd.DataFrame({
-        "sample_id": ["B", "D"],
+        "donor_id": ["B", "D"],
         "days_at_censoring": [10, 20]
     }, index=[1, 3])
     pd.testing.assert_frame_equal(result, expected_data)
@@ -200,21 +196,21 @@ def mode():
     return "progression"
 
 #@pytest.mark.parametrize("mode", ["progression", "survival"])
-@patch("app.read_options_file")
+
 @patch("app.load_data")
-@patch("app.get_labels")
+@patch("app.get_dataset_ids")
 @patch("app.get_subsets")
 @patch("app.get_survival_days")
 @patch("app.get_exit_status")
 @patch("app.get_survival_function_and_censored_dfs")
 @patch("app.logrank_test")
 @patch("app.pd.DataFrame.to_csv")
-def test_main(mock_to_csv, mock_logrank_test, mock_get_survival_function_and_censored_dfs, mock_get_exit_status, mock_get_survival_days, mock_get_subsets, mock_get_labels, mock_load_data,mock_read_options_file, mock_data_df, tmp_path,mode):
+def test_main(mock_to_csv, mock_logrank_test, mock_get_survival_function_and_censored_dfs, mock_get_exit_status, mock_get_survival_days, mock_get_subsets, mock_get_dataset_ids, mock_load_data,mock_data_df, tmp_path,mode):
     # Mock the load_data function to return the mock data
     mock_load_data.return_value = mock_data_df
 
-    # Mock the get_labels function to return the labels
-    mock_get_labels.return_value = mock_data_df.label
+    # Mock the get_dataset_ids function to return the dataset_ids
+    mock_get_dataset_ids.return_value = mock_data_df.dataset_id
     
     # Mock the get_subsets function to return subsets of the data
     mock_get_subsets.return_value = ([mock_data_df.iloc[:2], mock_data_df.iloc[2:]], ["A", "B"])
@@ -227,12 +223,11 @@ def test_main(mock_to_csv, mock_logrank_test, mock_get_survival_function_and_cen
     
     # Mock the get_survival_function_and_censored_dfs function to return survival functions and censored data frames
     mock_get_survival_function_and_censored_dfs.side_effect = [
-        (pd.DataFrame({"time": [9, 19], "survival_prob": [0.9, 0.8]}), pd.DataFrame({"sample_id": ["A"], "days_at_censoring": [9]})),
-        (pd.DataFrame({"time": [14, 9], "survival_prob": [0.7, 0.6]}), pd.DataFrame({"sample_id": ["C"], "days_at_censoring": [14]}))
+        (pd.DataFrame({"time": [9, 19], "survival_prob": [0.9, 0.8]}), pd.DataFrame({"donor_id": ["A"], "days_at_censoring": [9]})),
+        (pd.DataFrame({"time": [14, 9], "survival_prob": [0.7, 0.6]}), pd.DataFrame({"donor_id": ["C"], "days_at_censoring": [14]}))
     ]
     
-    # mock the read_options_file function to return the mode
-    mock_read_options_file.return_value = {"mode":mode}
+
     # Mock the logrank_test function to return a DataFrame
     mock_logrank_test.return_value = pd.DataFrame({"test_statistic": [1.23], "p_value": [0.45]})
     
@@ -243,11 +238,11 @@ def test_main(mock_to_csv, mock_logrank_test, mock_get_survival_function_and_cen
     # Check if the load_data function was called
     mock_load_data.assert_called_once_with(os.path.join(str(tmp_path), "input.tsv"))
     
-    # Check if the get_labels function was called
-    mock_get_labels.assert_called_once_with(mock_data_df)
+    # Check if the get_dataset_ids function was called
+    mock_get_dataset_ids.assert_called_once_with(mock_data_df)
     
     # Check if the get_subsets function was called
-    mock_get_subsets.assert_called_once_with(mock_data_df, mock_data_df.label)
+    mock_get_subsets.assert_called_once_with(mock_data_df, mock_data_df.dataset_id)
     
     # Check if the get_survival_days function was called twice
     assert mock_get_survival_days.call_count == 2
@@ -274,8 +269,8 @@ def test_main(mock_to_csv, mock_logrank_test, mock_get_survival_function_and_cen
     assert actual_files == expected_files
 
 def test_logrank_test(mock_survival_data):
-    survival, exit_status,label = mock_survival_data
-    result = logrank_test(survival,exit_status,label)
+    survival, exit_status,dataset_id = mock_survival_data
+    result = logrank_test(survival,exit_status,dataset_id)
     
     # Check if the result is a DataFrame
     assert isinstance(result, pd.DataFrame)

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -4,43 +4,77 @@ import sys
 sys.path.append("./src")
 from app import estimate_survival_function
 import pytest
+from unittest.mock import patch
 import pandas as pd
-from app import get_survival_days_from_dates, get_survival_days_from_days, get_survival_days, load_data, get_censored_df
+from app import get_survival_days_from_dates, get_survival_days_from_days, get_survival_days, load_data, get_censored_df, get_survival_columns, get_exit_status, get_labels,get_subsets,  logrank_test, main
+import numpy as np
+import os
 
 @pytest.fixture
 def mock_survival_data():
     survival = pd.Series([5, 10, 15, 20, 25])
     exit_status = pd.Series([True, False, True, False, True])
-    return survival, exit_status
+    label = pd.Series(["A", "B", "A", "B", "A"])
+    return survival, exit_status,label
 
 @pytest.fixture
 def mock_data_df():
     data = pd.DataFrame({
         "diagnosis_date": ["2020-01-01", "2020-02-01", "2020-03-01"],
         "vital_status_change_date": ["2020-01-10", None, "2020-03-15"],
-        "vital_status_change_day": [9, 20, 14]
+        "vital_status_change_day": [9, 20, 14],
+        "vital_status": [False, True, False],
+        "progression_status": [True, False, True],
+        "progression_status_change_date": ["2020-01-10", None, "2020-03-15"],
+        "progression_status_change_day": [9, 20, 14],
+        "label": ["A", "B", "A"],
+        "sample_id": ["1", "2", "3"]
     })
+    return data
+@pytest.fixture
+def mock_data_df_truncated(mock_data_df):
+    data = mock_data_df.copy()
+    data = data[[True, False, True]]
     return data
 
 
 def test_load_data():
-    data = load_data("test/data/input.tsv")
+     data = load_data("test/data/input.tsv")
     
-    # Check if the result is a DataFrame
-    assert isinstance(data, pd.DataFrame)
+     # Check if the result is a DataFrame
+     assert isinstance(data, pd.DataFrame)
     
-    # Check if the DataFrame is not empty
-    assert not data.empty
-    # Check if the DataFrame has the correct number of columns
-    assert len(data.columns) == 5
-    # Check if the DataFrame has the correct columns
-    expected_columns = ["sample_id","diagnosis_date","vital_status","vital_status_change_date","vital_status_change_day"]
-    assert list(data.columns) == expected_columns
+     # Check if the DataFrame is not empty
+     assert not data.empty
+     # Check if the DataFrame has the correct number of columns
+     assert len(data.columns) == 9
+     # Check if the DataFrame has the correct columns
+     expected_columns = ["sample_id","diagnosis_date","vital_status","vital_status_change_date","vital_status_change_day","progression_status","progression_status_change_date","progression_status_change_day","label"]
+     assert list(data.columns) == expected_columns
+
+def test_get_labels(mock_data_df):
+    """ test the labels column is returned or a series of 0s if the column is not present"""
+    assert get_labels(mock_data_df).equals(pd.Series(["A", "B", "A"]))
+    # remove the label column
+    mock_data_df.drop("label", axis=1, inplace=True)
+    assert get_labels(mock_data_df).equals(pd.Series(["0", "0", "0"]))
 
 
+def test_get_subsets(mock_data_df):
+    """ test the subsets of the data are returned """
+    labels = mock_data_df.label
+    subsets,unique_labels = get_subsets(mock_data_df,labels)
+    
+    # check out put is a list of dataframes
+    assert isinstance(subsets,list)
+    assert all(isinstance(subset,pd.DataFrame) for subset in subsets)
+    # check the subsets are as expected
+    assert subsets[0].equals(mock_data_df.iloc[np.array(mock_data_df.label=="A"),:])
+    assert subsets[1].equals(mock_data_df.iloc[np.array(mock_data_df.label=="B"),:])
 
-def test_get_survival_days_from_dates(mock_data_df):
-    survival_days, success = get_survival_days_from_dates(mock_data_df)
+@pytest.mark.parametrize("census_date_column", ["progression_status_change_date", "vital_status_change_date"])
+def test_get_survival_days_from_dates(mock_data_df,census_date_column):
+    survival_days, success = get_survival_days_from_dates(mock_data_df,census_date_column)
     
     # Check if the result is a Series
     assert isinstance(survival_days, pd.Series)
@@ -51,12 +85,21 @@ def test_get_survival_days_from_dates(mock_data_df):
     pd.testing.assert_series_equal(survival_days, expected_survival_days)
     
     # Check if the success Series has the correct values
-    expected_success = pd.Series([True, False, True])
+    expected_success = pd.Series([ True,False,True])
+    pd.testing.assert_series_equal(success, expected_success)
+    
+    # try on truncated data
+    trunc_data = mock_data_df.copy()
+    trunc_data = trunc_data.iloc[[False, True, True],:]
+    survival_days, success = get_survival_days_from_dates(trunc_data,census_date_column)
+    expected_survival_days = pd.Series([None, 14],index=[1,2])
+    pd.testing.assert_series_equal(survival_days, expected_survival_days)
+    expected_success = pd.Series([False, True],index=[1,2])
     pd.testing.assert_series_equal(success, expected_success)
 
-
-def test_get_survival_days_from_days(mock_data_df):
-    survival_days, success = get_survival_days_from_days(mock_data_df)
+@pytest.mark.parametrize("census_day_column", ["progression_status_change_day", "vital_status_change_day"])
+def test_get_survival_days_from_days(mock_data_df,census_day_column):
+    survival_days, success = get_survival_days_from_days(mock_data_df,census_day_column)
     
     # Check if the result is a Series
     assert isinstance(survival_days, pd.Series)
@@ -69,11 +112,19 @@ def test_get_survival_days_from_days(mock_data_df):
     # Check if the success Series has the correct values
     expected_success = pd.Series([True, True, True],name="survival_days")
     pd.testing.assert_series_equal(success, expected_success)
+    
+    # try on truncated data (i.e. after subsetting)
+    trunc_data = mock_data_df.copy()
+    trunc_data = trunc_data.iloc[[False, True, True],:]
+    survival_days, success = get_survival_days_from_days(trunc_data,census_day_column)
+    expected_survival_days = pd.Series([20, 14],index=[1,2],name="survival_days",dtype=float)
+    pd.testing.assert_series_equal(survival_days, expected_survival_days)
+    expected_success = pd.Series([True, True],index=[1,2],name="survival_days")
 
+@pytest.mark.parametrize("type", ["progress", "vital"])
+def test_get_survival_days(mock_data_df,type):
 
-def test_get_survival_days(mock_data_df):
-
-    survival_days = get_survival_days(mock_data_df)
+    survival_days = get_survival_days(mock_data_df,type)
     
     # Check if the result is a Series
     assert isinstance(survival_days, pd.Series)
@@ -81,12 +132,30 @@ def test_get_survival_days(mock_data_df):
     # Check if the Series has the correct values
     expected_survival_days = pd.Series([9, 20, 14],name="survival_days",dtype=float)
     pd.testing.assert_series_equal(survival_days, expected_survival_days)
+     
+    # try on truncated data (i.e. after subsetting)
+    trunc_data = mock_data_df.copy()
+    survival_days = get_survival_days(trunc_data,type)
+    expected_survival_days = pd.Series([20, 14],index=[1,2],name="survival_days",dtype=float)
 
-
+@pytest.mark.parametrize("type", ["progress", "vital"])
+def test_get_exit_status(mock_data_df,type):
+    exit_status = get_exit_status(mock_data_df,type)
+    
+    # Check if the result is a Series
+    assert isinstance(exit_status, pd.Series)
+    
+    # Check if the Series has the correct values
+    if type == "progress":
+        expected_exit_status = pd.Series([True, False, True],name="progression_status",dtype=bool)
+    if type == "vital":
+        expected_exit_status = pd.Series([True, False, True],name="vital_status",dtype=bool)
+    pd.testing.assert_series_equal(exit_status, expected_exit_status)
+    
 
 
 def test_estimate_survival_function(mock_survival_data):
-    survival, exit_status = mock_survival_data
+    survival, exit_status,_ = mock_survival_data
     result = estimate_survival_function(survival, exit_status)
     
     # Check if the result is a DataFrame
@@ -112,7 +181,7 @@ def mock_data_for_censored():
 
 def test_get_censored_df(mock_data_for_censored):
     survival_days, exit_status, data = mock_data_for_censored
-    result = get_censored_df(survival_days, exit_status, data)
+    result = get_censored_df(survival_days, exit_status, data.sample_id)
     
     # Check if the result is a DataFrame
     assert isinstance(result, pd.DataFrame)
@@ -127,6 +196,108 @@ def test_get_censored_df(mock_data_for_censored):
         "days_at_censoring": [10, 20]
     }, index=[1, 3])
     pd.testing.assert_frame_equal(result, expected_data)
+
+@pytest.mark.parametrize("type", ["progress", "vital"])
+def test_get_survival_columns(type):
+    result = get_survival_columns(type)
+    if type == "progress":
+        expected_columns = ("progression_status_change_date","progression_status_change_day")
+    if type == "vital":
+        expected_columns = ("vital_status_change_date","vital_status_change_day")
+    assert result == expected_columns   
+
+
+@patch("app.load_data")
+@patch("app.get_labels")
+@patch("app.get_subsets")
+@patch("app.get_survival_days")
+@patch("app.get_exit_status")
+@patch("app.get_survival_function_and_censored_dfs")
+@patch("app.logrank_test")
+@patch("app.pd.DataFrame.to_csv")
+def test_main(mock_to_csv, mock_logrank_test, mock_get_survival_function_and_censored_dfs, mock_get_exit_status, mock_get_survival_days, mock_get_subsets, mock_get_labels, mock_load_data, mock_data_df, tmp_path):
+    # Mock the load_data function to return the mock data
+    mock_load_data.return_value = mock_data_df
+    
+    # Mock the get_labels function to return the labels
+    mock_get_labels.return_value = mock_data_df.label
+    
+    # Mock the get_subsets function to return subsets of the data
+    mock_get_subsets.return_value = ([mock_data_df.iloc[:2], mock_data_df.iloc[2:]], ["A", "B"])
+    
+    # Mock the get_survival_days function to return survival days - 'side effect' is used to return different values for each call
+    mock_get_survival_days.side_effect = [pd.Series([9, 19]), pd.Series([14, 9])]
+    
+    # Mock the get_exit_status function to return exit status
+    mock_get_exit_status.side_effect = [pd.Series([False, True]), pd.Series([False, True])]
+    
+    # Mock the get_survival_function_and_censored_dfs function to return survival functions and censored data frames
+    mock_get_survival_function_and_censored_dfs.side_effect = [
+        (pd.DataFrame({"time": [9, 19], "survival_prob": [0.9, 0.8]}), pd.DataFrame({"sample_id": ["A"], "days_at_censoring": [9]})),
+        (pd.DataFrame({"time": [14, 9], "survival_prob": [0.7, 0.6]}), pd.DataFrame({"sample_id": ["C"], "days_at_censoring": [14]}))
+    ]
+    
+    # Mock the logrank_test function to return a DataFrame
+    mock_logrank_test.return_value = pd.DataFrame({"test_statistic": [1.23], "p_value": [0.45]})
+    
+    
+    # Call the main function
+    main(str(tmp_path), "vital")
+    
+    # Check if the load_data function was called
+    mock_load_data.assert_called_once_with(os.path.join(str(tmp_path), "input.tsv"))
+    
+    # Check if the get_labels function was called
+    mock_get_labels.assert_called_once_with(mock_data_df)
+    
+    # Check if the get_subsets function was called
+    mock_get_subsets.assert_called_once_with(mock_data_df, mock_data_df.label)
+    
+    # Check if the get_survival_days function was called twice
+    assert mock_get_survival_days.call_count == 2
+    
+    # Check if the get_exit_status function was called twice
+    assert mock_get_exit_status.call_count == 2
+    
+    # Check if the get_survival_function_and_censored_dfs function was called twice
+    assert mock_get_survival_function_and_censored_dfs.call_count == 2
+    
+    # Check if the to_csv function was called for each survival function and censored data frame
+    assert mock_to_csv.call_count == 5
+    
+    # Check if the logrank_test function was called
+    mock_logrank_test.assert_called_once()
+    
+    # Verify the filenames used in to_csv calls
+    expected_files = [
+        os.path.join(str(tmp_path), "resultA.tsv"),
+        os.path.join(str(tmp_path), "censoredA.tsv"),
+        os.path.join(str(tmp_path), "resultB.tsv"),
+        os.path.join(str(tmp_path), "censoredB.tsv"),
+        os.path.join(str(tmp_path), "logrank_test.tsv")
+    ]
+    actual_files = [call[0][0] for call in mock_to_csv.call_args_list]
+    assert actual_files == expected_files
+
+def test_logrank_test(mock_survival_data):
+    survival, exit_status,label = mock_survival_data
+    result = logrank_test(survival,exit_status,label)
+    
+    # Check if the result is a DataFrame
+    assert isinstance(result, pd.DataFrame)
+    
+    # Check if the DataFrame has the correct columns
+    expected_columns = ["chi2", "p"]
+    assert list(result.columns) == expected_columns
+    
+    # Check if the DataFrame has the correct number of rows
+    assert len(result) == 1
+    
+    # Check if the DataFrame has the correct values (example values, adjust as needed)
+    assert result["chi2"].iloc[0] == pytest.approx(1.163, rel=1e-2)
+    assert result["p"].iloc[0] == pytest.approx(0.280, rel=1e-2)
+
+
 
 # Run the tests
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary
To address the suggestions of Matthias this implements some new features:
- Multiple plots can be calculated for different subgroups with one call to "main"
- If more than one group is present a logrank test of differences among the groups is performed and output.
- Either overall survival or progression-free survival can be calculated

# Interface

- the input.tsv is expected to have the columns "dataset_id", "donor_id", "enrolment_date", "status", "status_change_date", "status_change_day"
- status must be be true if the event happened (patientd died/tumor progressed)
- The output files "result.tsv" and "censored.tsv" contain the results calculated separately for each dataset_id and then vertically concatenated. And additional column "dataset_id" in each of these files indicates the group to which they correspond.
- Each survival curve in "result.tsv" contains an additional row at the top of the curve corresponding to 0 days, for ease of plotting. 
- if there is more than one unique datset_id the file "logrank_test.tsv" will also be generated containing the chi-squared statistic and the p value of the logrank test. e.g.
```
chi2	p
1.5	0.4723665527410149
```